### PR TITLE
test: add integration tests

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,34 @@
+name: tests
+
+on:
+  pull_request:
+    branches:
+      - '*'
+  push:
+    branches:
+      - 'main'
+    tags:
+      - '*'
+  workflow_dispatch: {}
+
+jobs:
+  integration-tests:
+    runs-on: ubuntu-latest
+    steps:
+
+    - name: checkout repository
+      uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+
+    - name: install rust
+      uses: actions-rs/toolchain@v1
+      with:
+        toolchain: stable
+        override: true
+
+    - name: run integration tests
+      uses: actions-rs/cargo@v1
+      with:
+        command: test
+        args: -v -- --nocapture --ignored

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,20 +10,19 @@ homepage = "https://gateway-api.sigs.k8s.io/"
 repository = "https://github.com/kube-rs/gateway-api-rs"
 edition = "2021"
 
-[features]
-default = ["openssl-tls", "kubederive", "ws", "latest", "runtime"]
-kubederive = ["kube/derive"]
-openssl-tls = ["kube/client", "kube/openssl-tls"]
-rustls-tls = ["kube/client", "kube/rustls-tls"]
-runtime = ["kube/runtime"]
-ws = ["kube/ws"]
-latest = ["k8s-openapi/v1_25"]
-
 [dependencies]
-kube = { version = "^0.76.0", default-features = false, features = ["admission"] }
-kube-derive = { version = "^0.76.0", default-features = false } # only needed to opt out of schema
-k8s-openapi = { version = "0.16.0", default-features = false }
+kube = { version = "^0.76.0", default-features = false, features = ["derive"] }
+k8s-openapi = { version = "0.16.0" }
+schemars = "0.8.6"
 serde = { version = "1.0.130", features = ["derive"] }
 serde_json = "1.0.68"
 serde_yaml = "0.8.21"
-schemars = "0.8.6"
+
+[dev-dependencies]
+anyhow = "1.0.66"
+hyper = "0.14.23"
+kube = { version = "^0.76.0" }
+k8s-openapi = { version = "0.16.0" , features = ["v1_25"] }
+tokio = { version = "1.23.0", features = ["macros"] }
+tower = "0.4.13"
+uuid = { version = "1.1.2", features = ["v4", "fast-rng"] }

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,3 @@
+.PHONY: test.all
+test.all:
+	cargo test -vv -- --nocapture --ignored

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,1 +1,182 @@
 pub mod apis;
+
+#[cfg(test)]
+mod tests {
+    use std::process::Command;
+
+    use anyhow::Error;
+    use kube::api::PostParams;
+    use kube::client::ConfigExt;
+    use kube::config::{KubeConfigOptions, Kubeconfig};
+    use kube::core::ObjectMeta;
+    use kube::{Api, Config, CustomResourceExt};
+    use tower::ServiceBuilder;
+    use uuid::Uuid;
+
+    use crate::apis::standard::{
+        gatewayclasses::{GatewayClass, GatewayClassSpec},
+        gateways::{Gateway, GatewaySpec},
+    };
+
+    // -------------------------------------------------------------------------
+    // Tests
+    // -------------------------------------------------------------------------
+
+    #[ignore]
+    #[tokio::test]
+    async fn deploy_gateway() -> Result<(), Error> {
+        let (client, cluster) = get_client().await?;
+        let info = client.apiserver_version().await?;
+
+        println!(
+            "kind cluster {} is running, server version: {}",
+            cluster.name, info.git_version
+        );
+
+        let mut gwc = GatewayClass {
+            metadata: ObjectMeta::default(),
+            spec: GatewayClassSpec {
+                controller_name: "test-controller".to_string(),
+                description: None,
+                parameters_ref: None,
+            },
+            status: None,
+        };
+        gwc.metadata.name = Some("test-gateway-class".to_string());
+        gwc = Api::all(client.clone())
+            .create(&PostParams::default(), &gwc)
+            .await?;
+
+        assert!(gwc.metadata.name.is_some());
+        assert!(gwc.metadata.uid.is_some());
+
+        let mut gw = Gateway {
+            metadata: ObjectMeta::default(),
+            spec: GatewaySpec {
+                gateway_class_name: gwc
+                    .metadata
+                    .name
+                    .ok_or(Error::msg("could not find GatewayClass name"))?,
+                addresses: None,
+                listeners: vec![],
+            },
+            status: None,
+        };
+        gw.metadata.name = Some("test-gateway".to_string());
+        gw = Api::default_namespaced(client)
+            .create(&PostParams::default(), &gw)
+            .await?;
+
+        assert!(gw.metadata.name.is_some());
+        assert!(gw.metadata.uid.is_some());
+
+        Ok(())
+    }
+
+    // -------------------------------------------------------------------------
+    // Test Utilities
+    // -------------------------------------------------------------------------
+
+    struct Cluster {
+        name: String,
+    }
+
+    impl Drop for Cluster {
+        fn drop(&mut self) {
+            match delete_kind_cluster(&self.name) {
+                Err(err) => panic!("failed to cleanup kind cluster {}: {}", self.name, err),
+                Ok(()) => {}
+            }
+        }
+    }
+
+    async fn get_client() -> Result<(kube::Client, Cluster), Error> {
+        let cluster = create_kind_cluster()?;
+        let kubeconfig_yaml = get_kind_kubeconfig(&cluster.name)?;
+        let kubeconfig = Kubeconfig::from_yaml(&kubeconfig_yaml)?;
+        let config =
+            Config::from_custom_kubeconfig(kubeconfig, &KubeConfigOptions::default()).await?;
+
+        let service = ServiceBuilder::new()
+            .layer(config.base_uri_layer())
+            .option_layer(config.auth_layer()?)
+            .service(hyper::Client::builder().build(config.openssl_https_connector()?));
+
+        let client = kube::Client::new(service, config.default_namespace);
+
+        deploy_crds(client.clone()).await?;
+
+        Ok((client, cluster))
+    }
+
+    async fn deploy_crds(client: kube::Client) -> Result<(), Error> {
+        let mut gwc_crd = GatewayClass::crd();
+        gwc_crd.metadata.annotations = Some(std::collections::BTreeMap::from([(
+            "api-approved.kubernetes.io".to_string(),
+            "https://github.com/kubernetes/enhancements/pull/1111".to_string(),
+        )]));
+
+        Api::all(client.clone())
+            .create(&PostParams::default(), &gwc_crd)
+            .await?;
+
+        let mut gw_crd = Gateway::crd();
+        gw_crd.metadata.annotations = Some(std::collections::BTreeMap::from([(
+            "api-approved.kubernetes.io".to_string(),
+            "https://github.com/kubernetes/enhancements/pull/1111".to_string(),
+        )]));
+
+        Api::all(client.clone())
+            .create(&PostParams::default(), &gw_crd)
+            .await?;
+
+        Ok(())
+    }
+
+    fn create_kind_cluster() -> Result<Cluster, Error> {
+        let cluster_name = Uuid::new_v4().to_string();
+
+        let output = Command::new("kind")
+            .arg("create")
+            .arg("cluster")
+            .arg("--name")
+            .arg(&cluster_name)
+            .output()?;
+
+        if !output.status.success() {
+            return Err(Error::msg(String::from_utf8(output.stderr)?));
+        }
+
+        Ok(Cluster { name: cluster_name })
+    }
+
+    fn delete_kind_cluster(cluster_name: &str) -> Result<(), Error> {
+        let output = Command::new("kind")
+            .arg("delete")
+            .arg("cluster")
+            .arg("--name")
+            .arg(cluster_name)
+            .output()?;
+
+        if !output.status.success() {
+            return Err(Error::msg(String::from_utf8(output.stderr)?));
+        }
+
+        Ok(())
+    }
+
+    fn get_kind_kubeconfig(cluster_name: &str) -> Result<String, Error> {
+        let output = Command::new("kind")
+            .arg("get")
+            .arg("kubeconfig")
+            .arg("--name")
+            .arg(cluster_name)
+            .output()?;
+
+        if !output.status.success() {
+            return Err(Error::msg(String::from_utf8(output.stderr)?));
+        }
+
+        Ok(String::from_utf8(output.stdout)?)
+    }
+}


### PR DESCRIPTION
This PR adds some initial integration tests and adds them to ci workflows, and also includes some `Cargo.toml` cleanup according to #2, as the initial POC had an overloaded copy/pasted `Cargo.toml`.

Resolves #2 