### PR TITLE
Generate enums for Gateway condition types and reasons

### DIFF
--- a/gateway-api/src/apis/experimental/constants.rs
+++ b/gateway-api/src/apis/experimental/constants.rs
@@ -1,0 +1,75 @@
+// WARNING: generated file - manual changes will be overriden
+
+#[derive(Debug)]
+pub enum GatewayConditionType {
+    Programmed,
+    Accepted,
+    Ready,
+}
+
+impl std::fmt::Display for GatewayConditionType {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "{:?}", self)
+    }
+}
+
+#[derive(Debug)]
+pub enum GatewayConditionReason {
+    Programmed,
+    Invalid,
+    NoResources,
+    AddressNotAssigned,
+    AddressNotUsable,
+    Accepted,
+    ListenersNotValid,
+    Pending,
+    UnsupportedAddress,
+    InvalidParameters,
+    Ready,
+    ListenersNotReady,
+}
+
+impl std::fmt::Display for GatewayConditionReason {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "{:?}", self)
+    }
+}
+
+#[derive(Debug)]
+pub enum ListenerConditionType {
+    Conflicted,
+    Accepted,
+    ResolvedRefs,
+    Programmed,
+    Ready,
+}
+
+impl std::fmt::Display for ListenerConditionType {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "{:?}", self)
+    }
+}
+
+#[derive(Debug)]
+pub enum ListenerConditionReason {
+    HostnameConflict,
+    ProtocolConflict,
+    NoConflicts,
+    Accepted,
+    PortUnavailable,
+    UnsupportedProtocol,
+    ResolvedRefs,
+    InvalidCertificateRef,
+    InvalidRouteKinds,
+    RefNotPermitted,
+    Programmed,
+    Invalid,
+    Pending,
+    Ready,
+}
+
+impl std::fmt::Display for ListenerConditionReason {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "{:?}", self)
+    }
+}

--- a/gateway-api/src/apis/experimental/mod.rs
+++ b/gateway-api/src/apis/experimental/mod.rs
@@ -1,4 +1,5 @@
 // WARNING! generated file do not edit
+pub mod constants;
 mod enum_defaults;
 pub mod gatewayclasses;
 pub mod gateways;

--- a/gateway-api/src/apis/standard/constants.rs
+++ b/gateway-api/src/apis/standard/constants.rs
@@ -1,0 +1,75 @@
+// WARNING: generated file - manual changes will be overriden
+
+#[derive(Debug)]
+pub enum GatewayConditionType {
+    Programmed,
+    Accepted,
+    Ready,
+}
+
+impl std::fmt::Display for GatewayConditionType {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "{:?}", self)
+    }
+}
+
+#[derive(Debug)]
+pub enum GatewayConditionReason {
+    Programmed,
+    Invalid,
+    NoResources,
+    AddressNotAssigned,
+    AddressNotUsable,
+    Accepted,
+    ListenersNotValid,
+    Pending,
+    UnsupportedAddress,
+    InvalidParameters,
+    Ready,
+    ListenersNotReady,
+}
+
+impl std::fmt::Display for GatewayConditionReason {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "{:?}", self)
+    }
+}
+
+#[derive(Debug)]
+pub enum ListenerConditionType {
+    Conflicted,
+    Accepted,
+    ResolvedRefs,
+    Programmed,
+    Ready,
+}
+
+impl std::fmt::Display for ListenerConditionType {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "{:?}", self)
+    }
+}
+
+#[derive(Debug)]
+pub enum ListenerConditionReason {
+    HostnameConflict,
+    ProtocolConflict,
+    NoConflicts,
+    Accepted,
+    PortUnavailable,
+    UnsupportedProtocol,
+    ResolvedRefs,
+    InvalidCertificateRef,
+    InvalidRouteKinds,
+    RefNotPermitted,
+    Programmed,
+    Invalid,
+    Pending,
+    Ready,
+}
+
+impl std::fmt::Display for ListenerConditionReason {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "{:?}", self)
+    }
+}

--- a/gateway-api/src/apis/standard/mod.rs
+++ b/gateway-api/src/apis/standard/mod.rs
@@ -1,4 +1,5 @@
 // WARNING! generated file do not edit
+pub mod constants;
 mod enum_defaults;
 pub mod gatewayclasses;
 pub mod gateways;

--- a/update.sh
+++ b/update.sh
@@ -71,6 +71,16 @@ ENUMS_WITH_DEFAULTS=${ENUMS_WITH_DEFAULTS:1}
 GATEWAY_API_ENUMS=${ENUMS_WITH_DEFAULTS} cargo xtask gen_enum_defaults >> gateway-api/src/apis/standard/enum_defaults.rs
 echo "mod enum_defaults;" >> gateway-api/src/apis/standard/mod.rs
 
+GATEWAY_CONDITION_CONSTANTS="GatewayConditionType=Programmed,Accepted,Ready"
+GATEWAY_REASON_CONSTANTS="GatewayConditionReason=Programmed,Invalid,NoResources,AddressNotAssigned,AddressNotUsable,Accepted,ListenersNotValid,Pending,UnsupportedAddress,InvalidParameters,Ready,ListenersNotReady"
+LISTENER_CONDITION_CONSTANTS="ListenerConditionType=Conflicted,Accepted,ResolvedRefs,Programmed,Ready"
+LISTENER_REASON_CONSTANTS="ListenerConditionReason=HostnameConflict,ProtocolConflict,NoConflicts,Accepted,PortUnavailable,UnsupportedProtocol,ResolvedRefs,InvalidCertificateRef,InvalidRouteKinds,RefNotPermitted,Programmed,Invalid,Pending,Ready"
+
+GATEWAY_CONDITION_CONSTANTS=${GATEWAY_CONDITION_CONSTANTS} GATEWAY_REASON_CONSTANTS=${GATEWAY_REASON_CONSTANTS} \
+    LISTENER_CONDITION_CONSTANTS=${LISTENER_CONDITION_CONSTANTS} LISTENER_REASON_CONSTANTS=${LISTENER_REASON_CONSTANTS} \
+    cargo xtask gen_condition_constants >> gateway-api/src/apis/standard/constants.rs
+echo "pub mod constants;" >> gateway-api/src/apis/standard/mod.rs
+
 echo "// WARNING! generated file do not edit" > gateway-api/src/apis/experimental/mod.rs
 
 for API in "${EXPERIMENTAL_APIS[@]}"
@@ -96,6 +106,11 @@ ENUMS_WITH_DEFAULTS=$(printf ",%s" "${ENUMS[@]}")
 ENUMS_WITH_DEFAULTS=${ENUMS_WITH_DEFAULTS:1}
 GATEWAY_API_ENUMS=${ENUMS_WITH_DEFAULTS} cargo xtask gen_enum_defaults >> gateway-api/src/apis/experimental/enum_defaults.rs
 echo "mod enum_defaults;" >> gateway-api/src/apis/experimental/mod.rs
+
+GATEWAY_CONDITION_CONSTANTS=${GATEWAY_CONDITION_CONSTANTS} GATEWAY_REASON_CONSTANTS=${GATEWAY_REASON_CONSTANTS} \
+    LISTENER_CONDITION_CONSTANTS=${LISTENER_CONDITION_CONSTANTS} LISTENER_REASON_CONSTANTS=${LISTENER_REASON_CONSTANTS} \
+    cargo xtask gen_condition_constants >> gateway-api/src/apis/experimental/constants.rs
+echo "pub mod constants;" >> gateway-api/src/apis/experimental/mod.rs
 
 # Format the code.
 cargo fmt


### PR DESCRIPTION
Add a xtask to generate enums for Condition types and reasons along with an implemention of the Display trait for easy stringification. Use xtask for Gateway Condition types and reasons: `GatewayConditionType`, `GatewayConditionReason`, `ListenerConditionType`, `ListenerConditionReason`.