### PR TITLE
feat: add constants for GatewayClass conditions

### DIFF
--- a/gateway-api/src/apis/experimental/constants.rs
+++ b/gateway-api/src/apis/experimental/constants.rs
@@ -1,6 +1,35 @@
 // WARNING: generated file - manual changes will be overriden
 
 #[derive(Debug, PartialEq, Eq)]
+pub enum GatewayClassConditionType {
+    Accepted,
+    SupportedVersion,
+}
+
+impl std::fmt::Display for GatewayClassConditionType {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "{:?}", self)
+    }
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum GatewayClassConditionReason {
+    Accepted,
+    InvalidParameters,
+    Pending,
+    Unsupported,
+    Waiting,
+    SupportedVersion,
+    UnsupportedVersion,
+}
+
+impl std::fmt::Display for GatewayClassConditionReason {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "{:?}", self)
+    }
+}
+
+#[derive(Debug, PartialEq, Eq)]
 pub enum GatewayConditionType {
     Programmed,
     Accepted,

--- a/gateway-api/src/apis/standard/constants.rs
+++ b/gateway-api/src/apis/standard/constants.rs
@@ -1,6 +1,32 @@
 // WARNING: generated file - manual changes will be overriden
 
 #[derive(Debug, PartialEq, Eq)]
+pub enum GatewayClassConditionType {
+    Accepted,
+}
+
+impl std::fmt::Display for GatewayClassConditionType {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "{:?}", self)
+    }
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum GatewayClassConditionReason {
+    Accepted,
+    InvalidParameters,
+    Pending,
+    Unsupported,
+    Waiting,
+}
+
+impl std::fmt::Display for GatewayClassConditionReason {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "{:?}", self)
+    }
+}
+
+#[derive(Debug, PartialEq, Eq)]
 pub enum GatewayConditionType {
     Programmed,
     Accepted,

--- a/update.sh
+++ b/update.sh
@@ -111,8 +111,8 @@ GATEWAY_API_ENUMS=${ENUMS_WITH_DEFAULTS} cargo xtask gen_enum_defaults >> gatewa
 echo "mod enum_defaults;" >> gateway-api/src/apis/experimental/mod.rs
 
 # GatewayClass conditions vary between standard and experimental
-GATEWAY_CLASS_CONDITION_CONSTANTS="GatewayClassConditionType=Accepted,SupportedVersion"
-GATEWAY_CLASS_REASON_CONSTANTS="GatewayClassConditionReason=Accepted,InvalidParameters,Pending,Unsupported,Waiting,SupportedVersion,UnsupportedVersion"
+GATEWAY_CLASS_CONDITION_CONSTANTS="${GATEWAY_CLASS_CONDITION_CONSTANTS},SupportedVersion"
+GATEWAY_CLASS_REASON_CONSTANTS="${GATEWAY_CLASS_REASON_CONSTANTS},SupportedVersion,UnsupportedVersion"
 
 GATEWAY_CLASS_CONDITION_CONSTANTS=${GATEWAY_CLASS_CONDITION_CONSTANTS} GATEWAY_CLASS_REASON_CONSTANTS=${GATEWAY_CLASS_REASON_CONSTANTS} \
     GATEWAY_CONDITION_CONSTANTS=${GATEWAY_CONDITION_CONSTANTS} GATEWAY_REASON_CONSTANTS=${GATEWAY_REASON_CONSTANTS} \

--- a/update.sh
+++ b/update.sh
@@ -71,12 +71,15 @@ ENUMS_WITH_DEFAULTS=${ENUMS_WITH_DEFAULTS:1}
 GATEWAY_API_ENUMS=${ENUMS_WITH_DEFAULTS} cargo xtask gen_enum_defaults >> gateway-api/src/apis/standard/enum_defaults.rs
 echo "mod enum_defaults;" >> gateway-api/src/apis/standard/mod.rs
 
+GATEWAY_CLASS_CONDITION_CONSTANTS="GatewayClassConditionType=Accepted"
+GATEWAY_CLASS_REASON_CONSTANTS="GatewayClassConditionReason=Accepted,InvalidParameters,Pending,Unsupported,Waiting"
 GATEWAY_CONDITION_CONSTANTS="GatewayConditionType=Programmed,Accepted,Ready"
 GATEWAY_REASON_CONSTANTS="GatewayConditionReason=Programmed,Invalid,NoResources,AddressNotAssigned,AddressNotUsable,Accepted,ListenersNotValid,Pending,UnsupportedAddress,InvalidParameters,Ready,ListenersNotReady"
 LISTENER_CONDITION_CONSTANTS="ListenerConditionType=Conflicted,Accepted,ResolvedRefs,Programmed,Ready"
 LISTENER_REASON_CONSTANTS="ListenerConditionReason=HostnameConflict,ProtocolConflict,NoConflicts,Accepted,PortUnavailable,UnsupportedProtocol,ResolvedRefs,InvalidCertificateRef,InvalidRouteKinds,RefNotPermitted,Programmed,Invalid,Pending,Ready"
 
-GATEWAY_CONDITION_CONSTANTS=${GATEWAY_CONDITION_CONSTANTS} GATEWAY_REASON_CONSTANTS=${GATEWAY_REASON_CONSTANTS} \
+GATEWAY_CLASS_CONDITION_CONSTANTS=${GATEWAY_CLASS_CONDITION_CONSTANTS} GATEWAY_CLASS_REASON_CONSTANTS=${GATEWAY_CLASS_REASON_CONSTANTS} \
+    GATEWAY_CONDITION_CONSTANTS=${GATEWAY_CONDITION_CONSTANTS} GATEWAY_REASON_CONSTANTS=${GATEWAY_REASON_CONSTANTS} \
     LISTENER_CONDITION_CONSTANTS=${LISTENER_CONDITION_CONSTANTS} LISTENER_REASON_CONSTANTS=${LISTENER_REASON_CONSTANTS} \
     cargo xtask gen_condition_constants >> gateway-api/src/apis/standard/constants.rs
 echo "pub mod constants;" >> gateway-api/src/apis/standard/mod.rs
@@ -107,7 +110,12 @@ ENUMS_WITH_DEFAULTS=${ENUMS_WITH_DEFAULTS:1}
 GATEWAY_API_ENUMS=${ENUMS_WITH_DEFAULTS} cargo xtask gen_enum_defaults >> gateway-api/src/apis/experimental/enum_defaults.rs
 echo "mod enum_defaults;" >> gateway-api/src/apis/experimental/mod.rs
 
-GATEWAY_CONDITION_CONSTANTS=${GATEWAY_CONDITION_CONSTANTS} GATEWAY_REASON_CONSTANTS=${GATEWAY_REASON_CONSTANTS} \
+# GatewayClass conditions vary between standard and experimental
+GATEWAY_CLASS_CONDITION_CONSTANTS="GatewayClassConditionType=Accepted,SupportedVersion"
+GATEWAY_CLASS_REASON_CONSTANTS="GatewayClassConditionReason=Accepted,InvalidParameters,Pending,Unsupported,Waiting,SupportedVersion,UnsupportedVersion"
+
+GATEWAY_CLASS_CONDITION_CONSTANTS=${GATEWAY_CLASS_CONDITION_CONSTANTS} GATEWAY_CLASS_REASON_CONSTANTS=${GATEWAY_CLASS_REASON_CONSTANTS} \
+    GATEWAY_CONDITION_CONSTANTS=${GATEWAY_CONDITION_CONSTANTS} GATEWAY_REASON_CONSTANTS=${GATEWAY_REASON_CONSTANTS} \
     LISTENER_CONDITION_CONSTANTS=${LISTENER_CONDITION_CONSTANTS} LISTENER_REASON_CONSTANTS=${LISTENER_REASON_CONSTANTS} \
     cargo xtask gen_condition_constants >> gateway-api/src/apis/experimental/constants.rs
 echo "pub mod constants;" >> gateway-api/src/apis/experimental/mod.rs

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -109,11 +109,11 @@ fn gen_enum_defaults() -> Result<(), DynError> {
     println!("{}", gen_generated_file_warning());
 
     // Generate use statements for the enums.
-    if httproute_enums.len() > 0 {
+    if !httproute_enums.is_empty() {
         let use_http_stmt = gen_use_stmt(httproute_enums, "httproutes".to_string());
         println!("{}\n", use_http_stmt);
     }
-    if grpcroute_enums.len() > 0 {
+    if !grpcroute_enums.is_empty() {
         let use_grpc_stmt = gen_use_stmt(grpcroute_enums, "grpcroutes".to_string());
         println!("{}\n", use_grpc_stmt);
     }
@@ -127,7 +127,7 @@ fn gen_generated_file_warning() -> String {
 }
 
 fn gen_use_stmt(items: Vec<String>, module: String) -> String {
-    let mut stmt = String::from(format!("use super::{}::{{", module));
+    let mut stmt = format!("use super::{}::{{", module);
     for item in items {
         stmt.push_str(format!("{}, ", item).as_str());
     }

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -25,12 +25,16 @@ gen_constants generates constants used for Conditions
 type DynError = Box<dyn std::error::Error>;
 
 fn gen_condition_constants() -> Result<(), DynError> {
+    let gateway_class_condition_types = env::var("GATEWAY_CLASS_CONDITION_CONSTANTS")?;
+    let gateway_class_reason_types = env::var("GATEWAY_CLASS_REASON_CONSTANTS")?;
     let gateway_condition_types = env::var("GATEWAY_CONDITION_CONSTANTS")?;
     let gateway_reason_types = env::var("GATEWAY_REASON_CONSTANTS")?;
     let listener_condition_types = env::var("LISTENER_CONDITION_CONSTANTS")?;
     let listener_reason_types = env::var("LISTENER_REASON_CONSTANTS")?;
 
     let mut scope = Scope::new();
+    gen_const_enums(&mut scope, gateway_class_condition_types);
+    gen_const_enums(&mut scope, gateway_class_reason_types);
     gen_const_enums(&mut scope, gateway_condition_types);
     gen_const_enums(&mut scope, gateway_reason_types);
     gen_const_enums(&mut scope, listener_condition_types);


### PR DESCRIPTION
- Add types `GatewayClassConditionType` and `GatewayClassConditionReason` for working with `GatewayClass` conditions.
- Note: the conditions vary between `standard` and `experimental` channels, although I didn't see any precedent for handling this in `update.sh` so I opted to just rebind the variables later on to add the `experimental` ones.
- Unrelated: resolves some `clippy` warnings in `xtask/src/main.rs`.

Fixes: https://github.com/kube-rs/gateway-api-rs/issues/98